### PR TITLE
Trigger CI everytime pushing new code

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,8 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - '**'
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
**Issue**
- Previously, the CI was only triggered when a pull request is generated. However, if the tests failed, and they want to abandon these changes, the legacy PR will be archived.

**Solution**
- Trigger CI every time new code is pushed, which gives members some hints if they needs to fix tests first before creating a PR.