### PR TITLE
Make dependencies more logic and integrated in gradle scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 plugins {
-    id 'org.springframework.boot' version '3.0.6'
     id 'com.palantir.git-version' version '3.0.0'
     id "com.avast.gradle.docker-compose" version "0.16.11"
+    id "io.freefair.lombok" version "8.0.1"
+    id "io.spring.dependency-management" version "1.1.0"
+    id 'org.springframework.boot' version '3.0.6' apply false
 }
 
 allprojects {
@@ -12,7 +14,7 @@ subprojects {
     apply plugin: 'com.palantir.git-version'
     apply plugin: 'java-library'
     apply plugin: 'java'
-    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.freefair.lombok'
     apply plugin: 'io.spring.dependency-management'
 
     group 'org.bugmakers404.hermes'
@@ -31,6 +33,18 @@ subprojects {
         mavenCentral()
     }
 
+    dependencies {
+        implementation platform('org.springframework.boot:spring-boot-dependencies:3.0.6')
+        implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+
+        testImplementation('org.springframework.boot:spring-boot-starter-test') {
+            exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+            exclude group: 'junit', module: 'junit'
+        }
+
+        testImplementation 'org.testng:testng:7.7.1'
+    }
+
     test {
         useTestNG()
         def appProps = findProperty('hermesProducerAppProps')
@@ -38,6 +52,8 @@ subprojects {
             systemProperty "spring.config.additional-location", appProps
         }
     }
+
+
 }
 
 def userName = findProperty('hermesMongoRootUserName').toString()

--- a/hermes-producer-main/build.gradle
+++ b/hermes-producer-main/build.gradle
@@ -1,16 +1,8 @@
+apply plugin: 'org.springframework.boot'
+
 dependencies {
     implementation project(':hermes-producer-vicroad')
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-        exclude group: 'junit', module: 'junit'
-    }
-
-    testImplementation 'org.testng:testng:7.7.1'
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }
 
 springBoot {

--- a/hermes-producer-vicroad/build.gradle
+++ b/hermes-producer-vicroad/build.gradle
@@ -2,25 +2,4 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-json'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.json:json:20230227'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-
-    testAnnotationProcessor 'org.projectlombok:lombok'
-
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-        exclude group: 'junit', module: 'junit'
-    }
-
-    testImplementation 'org.testng:testng:7.7.1'
-}
-
-//jar {
-//    from sourceSets.main.output
-//}
-//
-bootJar {
-    enabled = false
 }


### PR DESCRIPTION
**Issue**
Previously, there are some duplications in the dependencies among modules

**Solution**
Make dependencies lite and integrate most of them at root `build.gradle`.